### PR TITLE
Fix percentile panic...

### DIFF
--- a/src/worldgen/worldmap/utils/noise.rs
+++ b/src/worldgen/worldmap/utils/noise.rs
@@ -21,6 +21,13 @@ pub fn fractal_noise(
 /// Return the value below which `p` fraction of the slice lies.
 pub fn percentile(values: &mut [f64], p: f64) -> f64 {
     values.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let idx = ((values.len() as f64) * p).floor() as usize;
+    
+    let clamped_p = p.clamp(0.0, 1.0);
+    let mut idx = (clamped_p * values.len() as f64).floor() as usize;
+
+    if idx >= values.len() {
+        idx = values.len() - 1;
+    }
+
     values[idx]
 }


### PR DESCRIPTION
by clamping input and bounding index to avoid out-of-bounds access